### PR TITLE
chore: 🤖 increase timeout for both reporting endpoints

### DIFF
--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -21,7 +21,7 @@ data:
             return 405;
           }
           proxy_pass http://prometheus-operated.monitoring.svc.cluster.local:9090/api/v1/;
-          proxy_read_timeout 60s;
+          proxy_read_timeout 120s;
         }
 
         location /alertmanager/ {
@@ -29,7 +29,7 @@ data:
             return 405;
           }
           proxy_pass http://alertmanager-operated.monitoring.svc.cluster.local:9093/api/v2/;
-          proxy_read_timeout 60s;
+          proxy_read_timeout 120s;
         }  
       }
     }


### PR DESCRIPTION
team still seeing occasional issues on failing requests, nginx logs show timeouts