### PR TITLE
fix: 🐛 add resolver param for kube-dns internal svc endpoint

### DIFF
--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -9,6 +9,7 @@ data:
       worker_connections 1024;
     }
     http {
+      resolver kube-dns.kube-system.svc.cluster.local valid=30s;
       server {
         listen 8080;
 


### PR DESCRIPTION
should resolve new issue surfaced since setting dynamic dns lookup for monitoring endpoints