### PR TITLE
Update healthcheck for both endpoints

### DIFF
--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -4,6 +4,23 @@ metadata:
   name: nginx-config
   namespace: cloud-platform-monitoring-alerts
 data:
+  health_check.sh: |
+    #!/bin/bash
+
+    PROMETHEUS_STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://prometheus-operated.monitoring.svc.cluster.local:9090/-/ready)
+    if [ "$PROMETHEUS_STATUS" -ne 200 ]; then
+      echo "Prometheus is unhealthy"
+    exit 1
+    fi
+
+    ALERTMANAGER_STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://alertmanager-operated.monitoring.svc.cluster.local:9093/-/healthy)
+    if [ "$ALERTMANAGER_STATUS" -ne 200 ]; then
+      echo "Alertmanager is unhealthy"
+    exit 1
+    fi
+
+    echo "Endpoints are healthy"
+    exit 0
   nginx.conf: |
     events {
     }

--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -7,19 +7,14 @@ data:
   health_check.sh: |
     #!/bin/bash
 
-    PROMETHEUS_STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://prometheus-operated.monitoring.svc.cluster.local:9090/-/ready)
-    if [ "$PROMETHEUS_STATUS" -ne 200 ]; then
-      echo "Prometheus is unhealthy"
-    exit 1
+    if [ "$(curl -s -o /dev/null -w "%{http_code}" http://prometheus-operated.monitoring.svc.cluster.local:9090/-/ready)" -ne 200 ]; then
+      exit 1
     fi
 
-    ALERTMANAGER_STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://alertmanager-operated.monitoring.svc.cluster.local:9093/-/healthy)
-    if [ "$ALERTMANAGER_STATUS" -ne 200 ]; then
-      echo "Alertmanager is unhealthy"
-    exit 1
+    if [ "$(curl -s -o /dev/null -w "%{http_code}" http://alertmanager-operated.monitoring.svc.cluster.local:9093/-/healthy)" -ne 200 ]; then
+      exit 1
     fi
 
-    echo "Endpoints are healthy"
     exit 0
   nginx.conf: |
     events {

--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -19,7 +19,7 @@ data:
   nginx.conf: |
     events {
     }
-    
+
     http {
       resolver 10.100.0.10 valid=10s;
       error_log /var/log/nginx/error.log debug;

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -31,10 +31,15 @@ spec:
             - name: nginx-config
               mountPath: /etc/nginx/nginx.conf
               subPath: nginx.conf
+            - name: health-check-script
+              mountPath: /usr/local/bin/health_check.sh
+              subPath: health_check.sh
           livenessProbe:
-            httpGet:
-              path: /prometheus/status/runtimeinfo
-              port: 8080
+            exec:
+              command:
+                - /bin/bash
+                - -c
+                - /usr/local/bin/health_check.sh
             initialDelaySeconds: 20
             periodSeconds: 120
       volumes:
@@ -44,3 +49,9 @@ spec:
             items:
               - key: nginx.conf
                 path: nginx.conf
+        - name: health-check-script
+          configMap:
+            name: nginx-config
+            items:
+              - key: health_check.sh
+                path: health_check.sh


### PR DESCRIPTION
Previously, we were only using the Prometheus `runtimeinfo` for our livenessProbe.

User highlighted that prom calls were 200-ing, but alertmanager was failing. We can't do multiple proxy_pass checks in an nginx location config, so instead we have a bash script that is executed via livenessProbe to continually check that both Prometheus and AM are healthy, using their "default" healthy endpoints.