### PR TITLE
fix: 🐛 exec perms on the healthcheck script, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ The `cloud-platform-monitoring-alerts` namespace is granted locked-down pod acce
 
 User namespace access to the service itself is controlled via [this NetworkPolicy](https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-monitoring-alerts/04-networkpolicy.yaml#L29).
 
+
+## Healthchecks (livenessProbe config)
+
+This service has a custom livenessProbe in the form of a bash script that periodically checks the health of the Prometheus and Alertmanager endpoints. Its not possible to define multiple endpoint checks for livenessProbe config so this gets around that issue by signalling a failure if either of the endpoints become unreachable.
+
+Note that logs from the livenessProbe are not available in the pod logs. If you need to debug the healthcheck script, you'll want to exec into the pod and run the script manually.
+
 ## How to access
 
 Raise a PR against your Cloud Platform environment, adding the following to your `namespace` `labels`:

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -40,8 +40,8 @@ spec:
                 - /bin/bash
                 - -c
                 - /usr/local/bin/health_check.sh
-            initialDelaySeconds: 20
-            periodSeconds: 120
+            initialDelaySeconds: 10
+            periodSeconds: 30
       volumes:
         - name: nginx-config
           configMap:
@@ -55,3 +55,4 @@ spec:
             items:
               - key: health_check.sh
                 path: health_check.sh
+            defaultMode: 0755


### PR DESCRIPTION
Constant restarts were due to the script never actually running. This fixes that.